### PR TITLE
Simple documentation linkage fix for ScheduleEntry.is_due

### DIFF
--- a/celery/beat.py
+++ b/celery/beat.py
@@ -114,7 +114,7 @@ class ScheduleEntry(object):
                               "options": other.options})
 
     def is_due(self):
-        """See :meth:`~celery.schedule.schedule.is_due`."""
+        """See :meth:`~celery.schedules.schedule.is_due`."""
         return self.schedule.is_due(self.last_run_at)
 
     def __iter__(self):


### PR DESCRIPTION
The link to schedule.is_due at http://docs.celeryproject.org/en/latest/internals/reference/celery.beat.html is broken due to a missing "s" in the module name.
