### PR TITLE
Clarify that -B and --concurrency can't be used together

### DIFF
--- a/docs/userguide/periodic-tasks.rst
+++ b/docs/userguide/periodic-tasks.rst
@@ -224,6 +224,9 @@ this is convenient if you only intend to use one worker node::
 
     $ celeryd -B
 
+If you run celeryd with the `--concurrency` option, you cannot use `-B`
+because that would in effect run multiple celerybeat processes.
+
 Celerybeat needs to store the last run times of the tasks in a local database
 file (named `celerybeat-schedule` by default), so it needs access to
 write in the current directory, or alternatively you can specify a custom


### PR DESCRIPTION
In the user guide, it's not entirely clear to me if -B and --concurrency can be used together.  This change clarifies that.
